### PR TITLE
Expect a string instead of JSON from the IP detector

### DIFF
--- a/pkg/clientip.go
+++ b/pkg/clientip.go
@@ -1,7 +1,7 @@
 package pkg
 
 import (
-	"encoding/json"
+	"io/ioutil"
 
 	"github.com/oscartbeaumont/netlify-dynamic-dns/internal"
 )
@@ -12,27 +12,30 @@ const (
 	ipv6ApiEndpoint = "https://v6.ident.me/.json"
 )
 
-// Web Service Response Body
-type apiResponse struct {
-	Address string
-}
-
 // GetPublicIPv4 returns your public IPv4 addresss as a string
 func GetPublicIPv4() (ip string, err error) {
 	res, err := internal.Client.Get(ipv4ApiEndpoint)
 	if err != nil {
 		return "", err
 	}
-	var response apiResponse
-	return response.Address, json.NewDecoder(res.Body).Decode(&response)
+	defer res.Body.Close()
+	bodyBytes, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(bodyBytes), nil
 }
 
 // GetPublicIPv6 returns your public IPv6 addresss as a string
 func GetPublicIPv6() (ip string, err error) {
-	res, err := internal.Client.Get(ipv6ApiEndpoint)
+	res, err := internal.Client.Get(ipv4ApiEndpoint)
 	if err != nil {
 		return "", err
 	}
-	var response apiResponse
-	return response.Address, json.NewDecoder(res.Body).Decode(&response)
+	defer res.Body.Close()
+	bodyBytes, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(bodyBytes), nil
 }

--- a/pkg/clientip_test.go
+++ b/pkg/clientip_test.go
@@ -1,0 +1,23 @@
+package pkg
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestGetPublicIPv4(t *testing.T) {
+	ipv4, err := GetPublicIPv4()
+	if err != nil {
+		t.Error(err)
+		t.Fail()
+	}
+	matched, matchingErr := regexp.MatchString(`^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$`, ipv4)
+	if matchingErr != nil {
+		t.Error(err)
+		t.Fail()
+	}
+	if !matched {
+		t.Error("IPv4 does not match the required format")
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Not sure what the response was previously, but now the IP checker returns just a plain string even when JSON is requested. I made the necessary change and created a test suite for that particular function.

I changed the expected body for both, but wrote the test for IPv4 only.

This is my first even piece of Go code, so pardon me if it's not great in any way. You can let me know how I should change it before you merge it :) 