### PR TITLE
Add option to update root record rather than a subdomain

### DIFF
--- a/cmd/args.go
+++ b/cmd/args.go
@@ -5,13 +5,14 @@ var Version = "v0.0.0-dev"
 
 // Arguments stores the configuration which is determined from the command line arguments or environment varibles
 type Arguments struct {
-	AccessToken    string `arg:"env:NDDNS_ACCESS_TOKEN,required" help:"Netlify personal access token. Can be created at https://app.netlify.com/user/application"`
-	Zone           string `placeholder:"\"example.com\"" arg:"env:NDDNS_ZONE,required" help:"The Netlify DNS zone domain name"`
-	Record         string `placeholder:"\"home\"" arg:"env:NDDNS_RECORD,required" help:"The record in the DNS zone to set as your public IP"`
-	IPv6           bool   `default:"true" arg:"env:NDDNS_IPv6_ENABLED" help:"Whether the IPv6 record (AAAA) should also be updated."`
-	Interval       int    `placeholder:"5" arg:"env:NDDNS_INTERVAL" help:"The amount of minutes between sending updates. If 0 only a single update is done."`
-	zoneID         string `arg:"-"`
-	recordHostname string `arg:"-"`
+	AccessToken      string `arg:"env:NDDNS_ACCESS_TOKEN,required" help:"Netlify personal access token. Can be created at https://app.netlify.com/user/application"`
+	Zone             string `placeholder:"\"example.com\"" arg:"env:NDDNS_ZONE,required" help:"The Netlify DNS zone domain name"`
+	Record           string `placeholder:"\"home\"" arg:"env:NDDNS_RECORD" help:"The record in the DNS zone to set as your public IP"`
+	IPv6             bool   `default:"true" arg:"env:NDDNS_IPv6_ENABLED" help:"Whether the IPv6 record (AAAA) should also be updated."`
+	Interval         int    `placeholder:"5" arg:"env:NDDNS_INTERVAL" help:"The amount of minutes between sending updates. If 0 only a single update is done."`
+	UpdateRootRecord bool   `placeholder:"false" arg:"env:NDDNS_IS_ROOT" help:"Use to update the root record instead of a subdomain"`
+	zoneID           string `arg:"-"`
+	recordHostname   string `arg:"-"`
 }
 
 // Description is for alexflint/go-args

--- a/cmd/args.go
+++ b/cmd/args.go
@@ -10,7 +10,7 @@ type Arguments struct {
 	Record           string `placeholder:"\"home\"" arg:"env:NDDNS_RECORD" help:"The record in the DNS zone to set as your public IP"`
 	IPv6             bool   `default:"true" arg:"env:NDDNS_IPv6_ENABLED" help:"Whether the IPv6 record (AAAA) should also be updated."`
 	Interval         int    `placeholder:"5" arg:"env:NDDNS_INTERVAL" help:"The amount of minutes between sending updates. If 0 only a single update is done."`
-	UpdateRootRecord bool   `placeholder:"false" arg:"env:NDDNS_IS_ROOT" help:"Use to update the root record instead of a subdomain"`
+	UpdateRootRecord bool   `placeholder:"false" arg:"env:NDDNS_UPDATE_ROOT_RECORD" help:"Use to update the root record instead of a subdomain"`
 	zoneID           string `arg:"-"`
 	recordHostname   string `arg:"-"`
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -36,7 +36,7 @@ func main() {
 	validation := arg.MustParse(&args)
 	args.zoneID = strings.ReplaceAll(args.Zone, ".", "_")
 
-	if args.UpdateRootRecord == false && args.Record == "" {
+	if !args.UpdateRootRecord && args.Record == "" {
 		validation.Fail("Either --record or --updaterootrecord must be provided")
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -46,8 +46,6 @@ func main() {
 		args.recordHostname = args.Record + "." + args.Zone
 	}
 
-	fmt.Println(args.recordHostname)
-
 	var lastAnalyticsReport time.Time
 	var forBreak = true
 	for forBreak {
@@ -116,7 +114,6 @@ func doUpdate() error {
 	var existingAAAARecord *models.DNSRecord
 	for _, record := range resp.Payload {
 		if record.Hostname == args.recordHostname {
-			fmt.Println("\n", record.Hostname, " ", record.Type)
 			if record.Type == "A" {
 				existingARecord = record
 			} else if record.Type == "AAAA" {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,20 +33,20 @@ var netlifyAuth = runtime.ClientAuthInfoWriterFunc(func(r runtime.ClientRequest,
 var ipProvider publicip.Provider = publicip.OpenDNSProvider{}
 
 func main() {
-    validation := arg.MustParse(&args)
+	validation := arg.MustParse(&args)
 	args.zoneID = strings.ReplaceAll(args.Zone, ".", "_")
 
-    if args.UpdateRootRecord == false && args.Record == "" {
-        validation.Fail("Either --record or --updaterootrecord must be provided")
-    }
+	if args.UpdateRootRecord == false && args.Record == "" {
+		validation.Fail("Either --record or --updaterootrecord must be provided")
+	}
 
-    if args.UpdateRootRecord {
-        args.recordHostname = args.Zone
-    } else {
-	    args.recordHostname = args.Record + "." + args.Zone
-    }
+	if args.UpdateRootRecord {
+		args.recordHostname = args.Zone
+	} else {
+		args.recordHostname = args.Record + "." + args.Zone
+	}
 
-    fmt.Println(args.recordHostname)
+	fmt.Println(args.recordHostname)
 
 	var lastAnalyticsReport time.Time
 	var forBreak = true
@@ -116,7 +116,7 @@ func doUpdate() error {
 	var existingAAAARecord *models.DNSRecord
 	for _, record := range resp.Payload {
 		if record.Hostname == args.recordHostname {
-            fmt.Println("\n", record.Hostname, " ", record.Type)
+			fmt.Println("\n", record.Hostname, " ", record.Type)
 			if record.Type == "A" {
 				existingARecord = record
 			} else if record.Type == "AAAA" {


### PR DESCRIPTION
Heya! I recently used this tool when setting up a home webserver and it's been super handy, but I did encounter one limitation in that the tool assumes you want to update a subdomain rather than the root domain record. I added an option to support this.

Potential discussion points:
- I haven't updated the tests as they seem to require running against real Netlify data so I didn't feel comfortable running them at present
- If the root record is currently occupied by a NETLIFY record, updating will fail since we only check for A/AAAA records to delete prior to creation. Not sure if we want to account for those in the code or just leave it to the user to make sure there are no clashes first

Anyway, it is Christmas time so I don't expect any immediate attention on this. Happy holiday!